### PR TITLE
fix: update bot to make multiple batch_renew txs

### DIFF
--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -6,7 +6,7 @@ use discord::{log_domains_renewed, log_error_and_send_to_discord, log_msg_and_se
 use mongodb::{options::ClientOptions, Client as mongoClient};
 use starknet::{
     accounts::SingleOwnerAccount,
-    core::{chain_id, types::FieldElement},
+    core::chain_id,
     signers::{LocalWallet, SigningKey},
 };
 use tokio::time::sleep;


### PR DESCRIPTION
This PR updates the renewal bot. 
The renewal of a domain takes approximately 5k steps. To avoid hitting the 2M step limit in a transaction, we send only 400 domains to be renewed in one transaction. 