### PR TITLE
fix: continue bot if request rate error happens

### DIFF
--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -171,7 +171,14 @@ pub async fn renew_domains(
         let renewers = domains.1.drain(0..size).collect();
 
         match send_transaction(config, account, (domains_to_renew.clone(), renewers)).await {
-            Ok(_) => (),
+            Ok(_) => {
+                log_msg_and_send_to_discord(
+                    &config,
+                    "[Renewal]",
+                    &format!("Successfully renewed domains: {:?}", domains_to_renew),
+                )
+                .await
+            }
             Err(e) => {
                 log_msg_and_send_to_discord(
                     &config,

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -174,7 +174,7 @@ pub async fn renew_domains(
             Ok(_) => {
                 log_msg_and_send_to_discord(
                     &config,
-                    "[Renewal]",
+                    "[bot][renew_domains]",
                     &format!("Successfully renewed domains: {:?}", domains_to_renew),
                 )
                 .await
@@ -182,7 +182,7 @@ pub async fn renew_domains(
             Err(e) => {
                 log_msg_and_send_to_discord(
                     &config,
-                    "[Renewal]",
+                    "[bot][renew_domains]",
                     &format!(
                         "Error while renewing domains: {:?} for domains: {:?}",
                         e, domains_to_renew

--- a/bot/src/main.rs
+++ b/bot/src/main.rs
@@ -113,7 +113,11 @@ async fn main() {
                                     &e,
                                 )
                                 .await;
-                                break;
+                                if e.to_string().contains("request rate limited") {
+                                    continue;
+                                } else {
+                                    break;
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
This PR allow the renewal bot to continue if we get an error that contains `Request rate limited` and add adds more logs. 