### PR TITLE
fix: typing & update indexer

### DIFF
--- a/bot/src/models.rs
+++ b/bot/src/models.rs
@@ -37,7 +37,7 @@ pub struct Chain {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DomainAggregateResult {
     pub domain: String,
-    pub expiry: Option<DateTime>,
+    pub expiry: Option<i32>,
     pub renewer_address: String,
     pub auto_renewal_enabled: bool,
     pub approval_value: String,


### PR DESCRIPTION
This PR fixes : 
- typing error in the result of the query to the indexer
- an infinite loop in `renew_domains` function