### PR TITLE
fix: update pipeline & fix price calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+config.testnet.toml

--- a/bot/src/bot.rs
+++ b/bot/src/bot.rs
@@ -459,24 +459,20 @@ pub async fn send_transaction(
     );
     calldata.extend_from_slice(&aggregate_results.meta_hashes);
 
-    println!("calldata: {:?}", calldata);
+    let result = account
+        .execute(vec![Call {
+            to: config.contract.renewal,
+            selector: selector!("batch_renew"),
+            calldata,
+        }])
+        .send()
+        .await;
 
-    Ok(())
-
-    // let result = account
-    //     .execute(vec![Call {
-    //         to: config.contract.renewal,
-    //         selector: selector!("batch_renew"),
-    //         calldata,
-    //     }])
-    //     .send()
-    //     .await;
-
-    // match result {
-    //     Ok(_) => Ok(()),
-    //     Err(e) => {
-    //         let error_message = format!("An error occurred while renewing domains: {}", e);
-    //         Err(anyhow::anyhow!(error_message))
-    //     }
-    // }
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let error_message = format!("An error occurred while renewing domains: {}", e);
+            Err(anyhow::anyhow!(error_message))
+        }
+    }
 }


### PR DESCRIPTION
This PR : 
- updates the pipeline to start with `auto_renew_flows` set to true instead of `domains` to speed up the query
- fixes the `fetch_domain_prices` to work with the current pricing contract version (accepting an encoded domain, instead of the length of the domain)